### PR TITLE
adding error handling for non-existant parse file arg

### DIFF
--- a/pyprof/parse/parse.py
+++ b/pyprof/parse/parse.py
@@ -5,6 +5,7 @@ Parse the SQLite3 database from NVprof or Nsight and print a dictionary for ever
 """
 
 import sys
+import os
 import argparse
 from tqdm import tqdm
 
@@ -21,6 +22,10 @@ def parseArgs():
 		help="SQLite3 database.")
 
 	args = parser.parse_args()
+
+	if not os.path.isfile(args.file):
+		raise parser.error("No such file '{}'.".format(args.file))
+
 	return args
 
 def dbIsNvvp(db):


### PR DESCRIPTION
Hello and thank you for the great tool.  I noticed that if you run parse.py on a nonexistent file like

`pyprof/parse/parse.py nonexistent_file.sql > net.dict`

there is no error thrown and `net.dict` contains `no such table: CUPTI_ACTIVITY_KIND_KERNEL`.  I added very simple error handling for the case of a non-existent input file.